### PR TITLE
script URL fixed in README

### DIFF
--- a/README
+++ b/README
@@ -47,7 +47,7 @@ STATIC SCRIPT
 ----------------------------------------------------------------------------
 to fetch and run the script without having to install the libraries you can
 just run:
-     curl https://raw.github.com/Netflix-Skunkworks/jenkins-cli/master/jenkins-static > ./jenkins
+     curl -L https://raw.githubusercontent.com/Netflix-Skunkworks/jenkins-cli/master/jenkins-static > ./jenkins
      chmod 755 ./jenkins
 
 COPYRIGHT and LICENSE


### PR DESCRIPTION
The correct URL is now on `raw.githubusercontent.com` instead of `raw.github.com`. This commit also adds `-L` to tell `curl` to follow redirections, in case the URL changes again.

See:

```
$ curl -I https://raw.github.com/Netflix-Skunkworks/jenkins-cli/master/jenkins-static
HTTP/1.1 301 Moved Permanently
Date: Wed, 17 Dec 2014 00:13:13 GMT
Server: Apache
Location: https://raw.githubusercontent.com/Netflix-Skunkworks/jenkins-cli/master/jenkins-static
…
```
